### PR TITLE
Fix replace-relative-paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "precommit": "npm run lint",
     "cordova": "npm run build-spa && npm run replace-relative-paths && npm run copy-cordova && npm run run-android;",
     "build-spa": "nuxt build --spa",
-    "replace-relative-paths": "replace '/nuxtfiles/' 'nuxtfiles/' dist --recursive && replace '/assets/' 'nuxtfiles/' dist --recursive && replace '(href|src|\"href\"|\"src\")=\"/' '$1=\"../' dist --recursive && replace '(href|src|\"href\"|\"src\"):\"/' '$1:\"../' dist --recursive",
+    "replace-relative-paths": "replace '/nuxtfiles/' 'nuxtfiles/' dist --recursive && replace '/assets/' 'nuxtfiles/' dist --recursive && replace 'nuxtfiles/(img|fonts)' '../nuxtfiles/$1' && replace '(href|src|\"href\"|\"src\")=\"/' '$1=\"../' dist --recursive && replace '(href|src|\"href\"|\"src\"):\"/' '$1:\"../' dist --recursive",
     "copy-cordova": "cp -R dist/* cordova/www/",
     "clear-cordova": "rm -R cordova/www/*",
     "run-android": "cd cordova && cordova run android"


### PR DESCRIPTION
Add replacer for using structure like /assets/(img|fonts) with dependencies node-sass and sass-loader